### PR TITLE
(WIP) Attempt to fix hard upload failures during quota events

### DIFF
--- a/apps/dav/lib/Upload/ChunkingV2Plugin.php
+++ b/apps/dav/lib/Upload/ChunkingV2Plugin.php
@@ -255,7 +255,7 @@ class ChunkingV2Plugin extends ServerPlugin {
 
 	public function beforeDelete(RequestInterface $request, ResponseInterface $response) {
 		try {
-			$this->prepareUpload($request->getPath());
+			$this->prepareUpload(dirname($request->getPath()));
 			if (!$this->uploadFolder instanceof UploadFolder) {
 				return true;
 			}


### PR DESCRIPTION
This is an attempt to fix a backend fail triggered by quota issues while uploading.

* Related to: #37578 <!-- related github issue -->

## Summary

I discovered this while trying to reproduce #37578. Technically this _may_ fix that issue as well (it's the same call/code path with a null parameter), but I was only able to reproduce the issue reported there under one condition: if upload would cause the user quota to be exceeded. 

In the course of looking into the issue I could reproduce, I came up with this "fix". This area of code is not one I was at all 
familiar with previously so I can't say I'd even give a "LGTM" even though I'm the one submitting it. There *is* an issue, but the best fix may me a variation.

In `prepareUpload()` the `$request->getPath()` will contain something like:

* w/o dirname: `uploads/ncadmin/web-file-upload-464f2b6a78f780318dc46e3424dbc0fc-1680893450217` (note it doesn't have the chunk # unlike beforePut())
* w/ dirname: `uploads/ncadmin`
                        
Currently we pass the whole thing (1st one) here to prepareUpload() which fails under at least one confirmed scenario (quota exceeded situations).

Without this patch, uploads fail in an ugly way on the backend when the quota is exceeded:

`TypeError: OCA\DAV\Upload\ChunkingV2Plugin::getUploadStorage(): Argument #1 ($targetPath) must be of type string, null given, called in /var/www/html/apps/dav/lib/Upload/ChunkingV2Plugin.php on line 285`

This is _not_ an issue if the quota isn't triggered. Though, interestingly, $uploadMetadata is _always_ blank

As far as I can tell $uploadMetadata is *always* null.

---

uploadPath gets set in prepareUpload()
  It gets set to either:
	$uploadMetadata[self::UPLOAD_TARGET_PATH] or null

checkPrerequisuites() is called by beforePut() + beforeMove
  But _not_ by beforeDelete()
  Among other things it checks if uploadPath is null
	and throws a PreconditionFailed exception if so:
		"Missing metadata for chunked upload"

Since checkPrerequisites() is never called in beforeDelete()...
  beforeDelete() happily calls getUploadStorage() with a null...
    uploadPath


Observations:
	
The main way uploadPath ends up null is...
   ...if $uploadMetadata[self::UPLOAD_TARGET_PATH] isn't set...
   ...in prepareUpload()...
     ...which gets $uploadMetadata via...
	$this->cache->get($this->uploadFolder->getName()); 

---

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
